### PR TITLE
Fix node:path usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ dist
 !.yarn/sdks
 .yarn/versions
 .pnp.*
+
+# Solidity cache/ folder
+cache/

--- a/.gitignore
+++ b/.gitignore
@@ -122,6 +122,9 @@ dist
 # Stores VSCode versions used for testing VSCode extensions
 .vscode-test
 
+# VSCode Settings
+.vscode
+
 # yarn v2
 .yarn/*
 !.yarn/cache

--- a/src/internal/render-router.ts
+++ b/src/internal/render-router.ts
@@ -1,6 +1,6 @@
-import path from 'node:path';
 import { JsonFragment } from '@ethersproject/abi';
 import { ethers } from 'ethers';
+
 import { ContractValidationError } from './errors';
 import { renderTemplate } from './render-template';
 import { routerFunctionFilter } from './router-function-filter';
@@ -34,7 +34,7 @@ interface BinaryData {
 
 export function renderRouter({
   routerName = 'Router',
-  template = path.resolve(__dirname, '..', '..', 'templates', 'Router.sol.mustache'),
+  template = require('path').resolve(__dirname, '..', '..', 'templates', 'Router.sol.mustache'),
   functionFilter = routerFunctionFilter,
   contracts,
 }: Props) {


### PR DESCRIPTION
Do not `import` the dependency `node:path` on root level, `require` only when necessary. This change is necessary to be able to load the project on browser context.