### PR TITLE
Remove node:fs dependency in favor of literal strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synthetixio/router",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "publishConfig": {
     "access": "public"
   },

--- a/src/internal/render-router.ts
+++ b/src/internal/render-router.ts
@@ -1,9 +1,10 @@
+import Mustache from 'mustache';
 import { JsonFragment } from '@ethersproject/abi';
 import { ethers } from 'ethers';
 
 import { ContractValidationError } from './errors';
-import { renderTemplate } from './render-template';
 import { routerFunctionFilter } from './router-function-filter';
+import { routerTemplate } from '../templates/router';
 import { toPrivateConstantCase } from './router-helper';
 
 const TAB = '    ';
@@ -34,7 +35,7 @@ interface BinaryData {
 
 export function renderRouter({
   routerName = 'Router',
-  template = require('path').resolve(__dirname, '..', '..', 'templates', 'Router.sol.mustache'),
+  template = routerTemplate,
   functionFilter = routerFunctionFilter,
   contracts,
 }: Props) {
@@ -48,7 +49,7 @@ export function renderRouter({
 
   const binaryData = _buildBinaryData(selectors);
 
-  return renderTemplate(template, {
+  return Mustache.render(template, {
     moduleName: routerName,
     modules: _renderModules(contracts),
     selectors: _renderSelectors(binaryData),

--- a/src/internal/render-template.ts
+++ b/src/internal/render-template.ts
@@ -1,7 +1,0 @@
-import fs from 'node:fs';
-import Mustache from 'mustache';
-
-export function renderTemplate(filepath: string, data: { [k: string]: unknown } = {}) {
-  const template = fs.readFileSync(filepath).toString();
-  return Mustache.render(template, data);
-}

--- a/src/templates/router.ts
+++ b/src/templates/router.ts
@@ -1,4 +1,4 @@
-//SPDX-License-Identifier: Unlicense
+export const routerTemplate = `//SPDX-License-Identifier: Unlicense
 pragma solidity ^0.8.0;
 
 // --------------------------------------------------------------------------------
@@ -49,3 +49,4 @@ contract {{{moduleName}}} {
         }
     }
 }
+`;


### PR DESCRIPTION
This change easily allows us to make the `generateFunction` compatible with browser (or any other) JS environment by removing the usage of the `node:fs` package.