### PR TITLE
add metadata when compiling

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,14 +1,17 @@
 {
+  "require": "ts-node/register",
   "diff": true,
   "recursive": true,
   "sort": true,
   "timeout": 10000,
-  "extension": ["ts"],
-  "spec": ["test/src/**/*.test.ts"],
+  "extension": [
+    "ts"
+  ],
+  "spec": [
+    "test/src/**/*.test.ts"
+  ],
   "watch-files": [
-    "src/**/*.ts",
-    "test/**/*.ts",
-    "test/**/*.sol",
-    "templates/*.mustache"
+    "src",
+    "test"
   ]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,10 @@
 .idea/
 .nyc_output/
 .yarn/
+.yarnrc.yml
+.mocharc.json
+cache/
 coverage/
 dist/
 node_modules/
-.yarnrc.yml
 package.json

--- a/compile.js
+++ b/compile.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/compilçe.js');

--- a/compile.ts
+++ b/compile.ts
@@ -1,0 +1,1 @@
+export * from './src/compile';

--- a/generate.js
+++ b/generate.js
@@ -1,0 +1,1 @@
+module.exports = require('./dist/generate.js');

--- a/generate.ts
+++ b/generate.ts
@@ -1,0 +1,1 @@
+export * from './src/generate';

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "scripts": {
     "build": "tsc",
     "watch": "tsc --watch",
-    "test": "mocha --require ts-node/register",
+    "test": "mocha",
     "coverage": "nyc yarn test",
     "test:watch": "yarn test --watch",
     "prepublishOnly": "yarn build",

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1,4 +1,24 @@
 import solc from 'solc';
+import { JsonFragment } from '@ethersproject/abi';
+
+interface CompileResult {
+  abi: JsonFragment[];
+  metadata: string;
+  solcVersion: string;
+  assembly: string;
+  bytecode: string;
+  deployedBytecode: string;
+  gasEstimates: {
+    creation: {
+      codeDepositCost: string;
+      executionCost: string;
+      totalCost: string;
+    };
+    external: {
+      '': string;
+    };
+  };
+}
 
 export function getCompileInput(contractName: string, sourceCode: string) {
   return {
@@ -23,6 +43,16 @@ export async function compileContract(contractName: string, sourceCode: string) 
   const input = getCompileInput(contractName, sourceCode);
 
   const solResult = JSON.parse(await solc.compile(JSON.stringify(input)));
+  const info = solResult.contracts[`${contractName}.sol`][contractName];
+  const metadata = JSON.parse(info.metadata);
 
-  return solResult.contracts[`${contractName}.sol`][contractName];
+  return {
+    abi: info.abi,
+    metadata: info.metadata,
+    solcVersion: metadata.compiler.version,
+    assembly: info.evm.assembly,
+    bytecode: info.evm.bytecode.object,
+    deployedBytecode: info.evm.deployedBytecode.object,
+    gasEstimates: info.evm.gasEstimates,
+  } as CompileResult;
 }

--- a/test/src/compile.test.ts
+++ b/test/src/compile.test.ts
@@ -1,0 +1,20 @@
+import { ok } from 'node:assert/strict';
+
+import { compileContract } from '../../src/compile';
+import { loadFile } from './helpers';
+
+describe('src/compile.ts', function () {
+  it('correctly compiles SampleRouter.sol', async function () {
+    const contractName = 'Router';
+    const sourceCode = await loadFile('../fixtures/SampleRouter.sol');
+    const result = await compileContract(contractName, sourceCode);
+
+    ok(Array.isArray(result.abi));
+    ok(typeof result.metadata === 'string');
+    ok(typeof result.solcVersion === 'string');
+    ok(typeof result.assembly === 'string');
+    ok(typeof result.bytecode === 'string');
+    ok(typeof result.deployedBytecode === 'string');
+    ok(result.gasEstimates);
+  });
+});

--- a/test/src/generate.test.ts
+++ b/test/src/generate.test.ts
@@ -1,12 +1,9 @@
-import fs from 'node:fs/promises';
-import path from 'node:path';
-import { deepEqual, throws } from 'assert/strict';
-import { generateRouter } from '../../src/generate';
-import { ContractValidationError } from '../../src/internal/errors';
-import abi from '../fixtures/SampleABI.json';
+import { deepEqual, throws } from 'node:assert/strict';
 
-const loadFile = (filepath: string) =>
-  fs.readFile(path.join(__dirname, filepath)).then((d) => d.toString());
+import abi from '../fixtures/SampleABI.json';
+import { ContractValidationError } from '../../src/internal/errors';
+import { generateRouter } from '../../src/generate';
+import { loadFile } from './helpers';
 
 describe('src/generate.ts', function () {
   it('throw an error when generating a router with repeated selectors', async function () {

--- a/test/src/helpers.ts
+++ b/test/src/helpers.ts
@@ -1,0 +1,5 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+
+export const loadFile = (filepath: string) =>
+  fs.readFile(path.join(__dirname, filepath)).then((d) => d.toString());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,9 +13,8 @@
     "skipLibCheck": true,
     "declaration": true,
     "declarationMap": true,
-    "sourceMap": true,
-    "types": ["node", "mocha"]
+    "sourceMap": true
   },
-  "include": ["src/**/*.ts"],
-  "exclude": []
+  "files": ["./src/declare.d.ts"],
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
This PR fixes the compile helper exports to be easier to use and adds `solcVersion` to the result.